### PR TITLE
Add 0.7 to compat version list

### DIFF
--- a/tex/latex/yquant/yquant.sty
+++ b/tex/latex/yquant/yquant.sty
@@ -23,7 +23,7 @@
 \RequirePackage{xkeyval}[2005/05/07]
 \usetikzlibrary{arrows.meta,decorations.pathreplacing,decorations.pathmorphing}
 
-\define@choicekey+{yquant.sty}{compat}[\val\yquant@compat]{newest,0.3,0.4,0.6}{
+\define@choicekey+{yquant.sty}{compat}[\val\yquant@compat]{newest,0.3,0.4,0.6,0.7}{
    \ifnum\yquant@compat=0 %
       \def\yquant@compat{3} % current version
    \fi%
@@ -32,7 +32,7 @@
 }
 \ProcessOptionsX
 \unless\ifdefined\yquant@compat
-   \PackageWarning{yquant.sty}{Please specify the `compat` key for yquant. Using `0.3`. Current compatibility version `0.6`.}
+   \PackageWarning{yquant.sty}{Please specify the `compat` key for yquant. Using `0.3`. Current compatibility version `0.7`.}
    \def\yquant@compat{1}
 \fi
 


### PR DESCRIPTION
Using `[compat=0.7]` in tex code resulted in the version to fall back to `0.3`. The compat string for version `0.7` was missing.